### PR TITLE
[fix] building correct pages by popping drawer first

### DIFF
--- a/lib/PageTemplate.dart
+++ b/lib/PageTemplate.dart
@@ -30,12 +30,14 @@ class PageTemplate extends StatelessWidget {
               ListTile(
                 title: IntrinsicWidth(child: SelectableText('Home')),
                 onTap: () {
+                  Navigator.of(context).pop();
                   Beamer.of(context).beamToNamed('/');
                 },
               ),
               ListTile(
                 title: SelectableText('Books'),
                 onTap: () {
+                  Navigator.of(context).pop();
                   Beamer.of(context).beamToNamed('/books');
                 },
               ),


### PR DESCRIPTION
I'm not sure what exactly happens, but it works correctly when we `pop` the `Drawer` first and then beam.